### PR TITLE
Exclude the command prefix and suffix from the shell_join()

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,5 @@ fixtures:
   symlinks:
     r11k: '#{source_dir}'
   repositories:
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    cron: 'https://github.com/puppetlabs/puppetlabs-cron_core.git'

--- a/spec/defines/r11k__cron_spec.rb
+++ b/spec/defines/r11k__cron_spec.rb
@@ -110,5 +110,26 @@ describe 'r11k::cron' do
         end
       end
     end
+
+    describe "with prefix/suffix" do
+      let(:params) do
+        default_params.merge(
+          command_prefix: '/usr/local/bin/wrapper',
+          command_suffix: '2>&1',
+          includes: ['production', 'puppet/.*']
+        )
+      end
+      it 'does not escape prefix/suffix' do
+        is_expected.to contain_cron('r11k::cron: default').with_command(
+          [ '/usr/local/bin/wrapper',
+            '/usr/local/bin/r11k --basedir /etc/puppetlabs/code/environments --no-wait --hooksdir /etc/r11k/hooks.d',
+            '--include production:puppet/.\\*',
+            '/local',
+            '2>&1',
+          ].join(' ')
+        )
+      end
+    end
+
   end
 end


### PR DESCRIPTION
For example to redirect all output to stdout.