### PR TITLE
Feature/env hooks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,8 +35,15 @@ Metrics/CyclomaticComplexity:
 Style/Documentation:
   Enabled: False
 
-Layout/DotPosition:
-  EnforcedStyle: trailing
+Style/TrailingCommaInLiteral:
+  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
+  Description: Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
   gem 'puppet-lint' # , '~> 2'
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper' # , '>= 1.2.1'
-  gem 'rubocop' # , '~> 0.48.1'
+  gem 'rubocop', '0.49.1' # puppet pdk pins this version
   gem 'rubocop-rspec' # , '~> 1.15'
 end
 group :doc do

--- a/files/r11k.sh
+++ b/files/r11k.sh
@@ -235,7 +235,7 @@ function do_submodules_for_branch() {
 	(
 		cd "${BASEDIR}/${branch_envname}"
 		git remote set-url origin "${MASTER_GIT_DIR}"
-		git remote update
+		git remote update --prune
 		if [[ -z "$(git status --porcelain -uno)" ]] && [[ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/${branch}")" ]] && [[ ${new_branch} == 'false' ]]
 		then
 			echo "${FONT_GREEN}Branch has no changes. ${FONT_NORMAL}${FONT_GREEN_BOLD}${branch}${FONT_NORMAL}"
@@ -249,6 +249,7 @@ function do_submodules_for_branch() {
 				cd "${BASEDIR}"
 				rm -rf "${branch_envname}"
 			fi
+			let CHANGE_COUNTER+=1
 		fi
 	)
 }

--- a/files/r11k.sh
+++ b/files/r11k.sh
@@ -259,6 +259,18 @@ function collect_branches() {
 	fi
 }
 
+function run_hooks() {
+	local hookdir="$1"
+	shift
+	local args="${@}"
+	[ -d "${hookdir}" ] || return
+	for SCRIPT in `ls "${hookdir}"`; do
+		if [ -x ${HOOKSDIR}/${SCRIPT} ]; then
+			${HOOKSDIR}/${SCRIPT} "${args[@]}"
+		fi
+	done
+}
+
 BRANCHES=( "$( collect_branches )" );
 CHANGE_COUNTER=0
 
@@ -284,10 +296,7 @@ done < <(cd "$BASEDIR"; ls -1)
 # if CHANGE_COUNTER > 0, run the all the hooks found in $HOOKSDIR
 if [ -d $HOOKSDIR ]; then
   if [ ${CHANGE_COUNTER} -gt 0 ]; then
-	for SCRIPT in `ls ${HOOKSDIR}`; do
-		# run script
-		${HOOKSDIR}/${SCRIPT}
-	done
+	run_hooks "${HOOKSDIR}"
   fi
 else
 	echo "WARNING: HOOKSDIR ${HOOKSDIR} not found"

--- a/files/r11k.sh
+++ b/files/r11k.sh
@@ -276,7 +276,7 @@ function run_hooks() {
 	for SCRIPT in `ls "${hookdir}"`; do
 		if [ -x ${hookdir}/${SCRIPT} ]; then
 			set +e
-			${hookdir}/${SCRIPT} "${args[@]}"
+			${hookdir}/${SCRIPT} ${args[@]}
 			exitcode=$?
 			set -e
 			if [ $exitcode -gt 0 ]; then

--- a/manifests/hook.pp
+++ b/manifests/hook.pp
@@ -15,6 +15,7 @@
 # @param config_umask Override the default umask (0600) for the configuration file.
 define r11k::hook (
   Enum['present','absent']       $ensure            = 'present',
+  Boolean                        $env_hook          = false,
   Optional[String]               $hook_content      = undef,
   Optional[String]               $hook_source       = undef,
   Optional[String]               $hook_dir          = undef,
@@ -26,7 +27,10 @@ define r11k::hook (
 ){
 
   $real_hooks_dir = $hook_dir ? {
-    undef   => $::r11k::default_hooks_dir,
+    undef   => $env_hook ? {
+      true    => $::r11k::default_env_hooks_dir,
+      default => $::r11k::default_hooks_dir,
+    },
     default => $hook_dir,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,9 @@ class r11k (
   # These are the default directories used in r11k::hook. Make sure they
   # exist to prevent a dependency / recursive directory creation mess
   $default_hooks_dir = '/etc/r11k/hooks.d'
+  $default_env_hooks_dir = '/etc/r11k/env.hooks.d'
 
-  file {['/etc/r11k','/etc/r11k/hooks.d','/etc/r11k/config']:
+  file {['/etc/r11k','/etc/r11k/hooks.d', '/etc/r11k/env.hooks.d', '/etc/r11k/config']:
     ensure => 'directory',
     mode   => '0755',
   }

--- a/spec/defines/r11k__cron_spec.rb
+++ b/spec/defines/r11k__cron_spec.rb
@@ -31,8 +31,8 @@ describe 'r11k::cron' do
         'git_base_repo' => '/path/to/repo',
         'job' => {
           'minute' => '*/10',
-          'hour' => ['2-4']
-        }
+          'hour' => ['2-4'],
+        },
       }
     end
 
@@ -46,14 +46,14 @@ describe 'r11k::cron' do
     [
       'production',
       nil,
-      ['production', 'features/.*']
+      ['production', 'features/.*'],
     ].each do |incl|
       describe "includes is a #{incl.class}" do
         let(:title) { 'default' }
         let(:params) do
           {
             'git_base_repo' => '/path/to/repo',
-            'includes' => incl
+            'includes' => incl,
           }
         end
 
@@ -65,8 +65,8 @@ describe 'r11k::cron' do
   end
 
   context 'with r11k command line' do
-    let(:prefix) { %w[/usr/local/bin/r11k] }
-    let(:suffix) { %w[/local] }
+    let(:prefix) { ['/usr/local/bin/r11k'] }
+    let(:suffix) { ['/local'] }
     let(:title) { 'default' }
     let(:default_params) { { 'git_base_repo' => '/local' } }
 
@@ -75,32 +75,32 @@ describe 'r11k::cron' do
         # use all defaults.
       },
       '--basedir /environments --no-wait --hooksdir /etc/r11k/hooks.d' => {
-        'basedir' => '/environments'
+        'basedir' => '/environments',
       },
       '--basedir /environments --no-wait --cachedir /tmp/cache --hooksdir /etc/r11k/hooks.d' => {
         'basedir' => '/environments',
-        'cachedir' => '/tmp/cache'
+        'cachedir' => '/tmp/cache',
       },
       '--basedir /environments --no-wait --cachedir /tmp/cache --hooksdir /etc/hooksdir' => {
         'basedir' => '/environments',
         'cachedir' => '/tmp/cache',
-        'hooksdir' => '/etc/hooksdir'
+        'hooksdir' => '/etc/hooksdir',
       },
       '--basedir /environments --no-wait --hooksdir /etc/hooksdir' => {
         'basedir' => '/environments',
-        'hooksdir' => '/etc/hooksdir'
+        'hooksdir' => '/etc/hooksdir',
       },
       '--basedir /environments --no-wait --hooksdir /etc/r11k/hooks.d --include production' => {
         'basedir' => '/environments',
-        'includes' => 'production'
+        'includes' => 'production',
       },
       '--basedir /environments --no-wait --hooksdir /etc/r11k/hooks.d --include production:puppet/.\\*' => {
         'basedir' => '/environments',
-        'includes' => ['production', 'puppet/.*']
+        'includes' => ['production', 'puppet/.*'],
       },
       '--basedir /path\\ with/spaces/ --no-wait --hooksdir /etc/r11k/hooks.d' => {
-        'basedir' => '/path with/spaces/'
-      }
+        'basedir' => '/path with/spaces/',
+      },
     }.each do |cmd, params|
       describe "expected result command: '#{cmd}'" do
         let(:params) { default_params.merge(params) }
@@ -111,25 +111,24 @@ describe 'r11k::cron' do
       end
     end
 
-    describe "with prefix/suffix" do
+    describe 'with prefix/suffix' do
       let(:params) do
         default_params.merge(
           command_prefix: '/usr/local/bin/wrapper',
           command_suffix: '2>&1',
-          includes: ['production', 'puppet/.*']
+          includes: ['production', 'puppet/.*'],
         )
       end
+
       it 'does not escape prefix/suffix' do
         is_expected.to contain_cron('r11k::cron: default').with_command(
-          [ '/usr/local/bin/wrapper',
-            '/usr/local/bin/r11k --basedir /etc/puppetlabs/code/environments --no-wait --hooksdir /etc/r11k/hooks.d',
-            '--include production:puppet/.\\*',
-            '/local',
-            '2>&1',
-          ].join(' ')
+          ['/usr/local/bin/wrapper',
+           '/usr/local/bin/r11k --basedir /etc/puppetlabs/code/environments --no-wait --hooksdir /etc/r11k/hooks.d',
+           '--include production:puppet/.\\*',
+           '/local',
+           '2>&1'].join(' '),
         )
       end
     end
-
   end
 end

--- a/spec/defines/r11k__hook_spec.rb
+++ b/spec/defines/r11k__hook_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'r11k::hook' do
+  let(:pre_condition) { 'include r11k' }
+  let(:title) { 'default' }
+  let(:params) { { hook_content: 'foobar' } }
+
+  context 'with defaults' do
+    it do
+      is_expected.to contain_file('/etc/r11k/hooks.d/default').with_content('foobar').with_ensure('file')
+    end
+  end
+
+  context 'env hook' do
+    let(:params) { super().merge(env_hook: true) }
+
+    it do
+      is_expected.to contain_file('/etc/r11k/env.hooks.d/default').with_content('foobar').with_ensure('file')
+    end
+  end
+
+  context 'config file' do
+    let(:params) do
+      super().merge(
+        config_file: '/etc/r11k/config/foobar.yaml',
+        config_source: 'puppet:///modules/foobar/config.yaml',
+      )
+    end
+
+    it do
+      is_expected.to contain_file('/etc/r11k/config/foobar.yaml')
+        .with_ensure('file')
+        .with_source('puppet:///modules/foobar/config.yaml')
+        .with_before('File[/etc/r11k/hooks.d/default]')
+    end
+  end
+
+  context 'with ensure => "absent"' do
+    let(:params) do
+      super().merge(
+        ensure: 'absent',
+        config_file: '/etc/r11k/config/foobar.yaml',
+      )
+    end
+
+    it do
+      is_expected.to contain_file('/etc/r11k/hooks.d/default').with_ensure('absent')
+    end
+    it do
+      is_expected.to contain_file('/etc/r11k/config/foobar.yaml').with_ensure('absent')
+    end
+  end
+
+  context 'parameter validation' do
+    describe 'hook missing content or source' do
+      let(:params) { super().merge(hook_content: :undef) }
+
+      it { is_expected.to compile.and_raise_error(%r{either the content or the source of the hook}) }
+    end
+
+    describe 'hook both content and source' do
+      let(:params) { super().merge(hook_source: 'puppet:///modules/foobar/default.sh') }
+
+      it { is_expected.to compile.and_raise_error(%r{either the content or the source of the hook. Not both}) }
+    end
+
+    describe 'config missing content or source' do
+      let(:params) { super().merge(config_file: '/etc/r11k/config/foobar.yaml') }
+
+      it { is_expected.to compile.and_raise_error(%r{config file, you must provide either the source or the content}) }
+    end
+
+    describe 'config both content and source' do
+      let(:params) do
+        super().merge(
+          config_file: '/etc/r11k/config/foobar.yaml',
+          config_source: 'puppet:///modules/foobar/config.yaml',
+          config_content: '---\nfoo',
+        )
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{config file, you must provide either the source or the content. Not both}) }
+    end
+  end
+
+  context 'hook_dependencies' do
+    let(:dependencies) do
+      {
+        'barfoo' => {},
+        'xfoo' => :undef,
+        'foobar' => { 'ensure' => 'latest' },
+      }
+    end
+
+    let(:params) do
+      super().merge(
+        hook_dependencies: dependencies,
+      )
+    end
+
+    it { is_expected.to contain_package('barfoo').with_ensure('installed') }
+    it { is_expected.to contain_package('xfoo').with_ensure('installed') }
+    it { is_expected.to contain_package('foobar').with_ensure('latest') }
+  end
+end


### PR DESCRIPTION
r11k:
Adds the ability to run hooks after each updated puppet environment:
* Extracted run hooks to a function
* Run environment hooks after each update with 2 arguments: branch name, environment name

puppet:
add support for env_hook in r11k::hook and add tests.